### PR TITLE
Fix interface-asset-schematics missing vscode settings

### DIFF
--- a/libs/tools/schematics/interface-asset-schematics/src/.gitignore
+++ b/libs/tools/schematics/interface-asset-schematics/src/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-.vscode/


### PR DESCRIPTION
Error when creating an interface asset with the schematics:
```
Error: Path "/node_modules/@intuiface/interface-asset/src/.vscode/settings.josn"does not exist.
```
