### PR TITLE
fix(core): generate correct syntax in ifd file for array of primitive

### DIFF
--- a/libs/core/src/lib/decorators/property.ts
+++ b/libs/core/src/lib/decorators/property.ts
@@ -78,9 +78,18 @@ export function Property(options?: IPropertyOptions)
         if (typeAndFormat.type === 'array' && options.itemType)
         {
             // store the item type
-            globalThis.intuiface_ifd_properties[targetName][propertyKey].items = {
-                $ref: options.itemType.name
-            };
+            let itemType: any = getTypeAndFormat(options.itemType, false);
+            if (itemType == null)
+            {
+                itemType = {
+                    $ref: options.itemType.name
+                };
+            }
+            else if (itemType.format === null)
+            {
+                delete itemType.format;
+            }
+            globalThis.intuiface_ifd_properties[targetName][propertyKey].items = itemType;
             // force array to be readOnly and delete default value
             globalThis.intuiface_ifd_properties[targetName][propertyKey].readonly = true;
             delete globalThis.intuiface_ifd_properties[targetName][propertyKey].default;

--- a/libs/core/src/lib/types/convertible.type.ts
+++ b/libs/core/src/lib/types/convertible.type.ts
@@ -7,7 +7,7 @@ import { Path } from './path.type';
  * @param type
  * @returns
  */
-export function getTypeAndFormat(type) {
+export function getTypeAndFormat(type, defaultsToString = true) {
     const typeAndFormat = { type: 'string', format: null };
     switch (type) {
         case Number:
@@ -36,6 +36,12 @@ export function getTypeAndFormat(type) {
             break;
         case Array:
             typeAndFormat.type = 'array';
+            break;
+        default:
+            if (!defaultsToString)
+            {
+                return null;
+            }
             break;
     }
     return typeAndFormat;


### PR DESCRIPTION
Item type  in ifd for primitive type in array should look like this:
```
"anArrayProperty": {
                    "type": "array",
                    "title": "My Array Property",
                    "readonly": true,
                    "items": {
                        "type": "string"
                    }
                }
```
instead of what is currently generated (fitting custom types):
```
"anArrayProperty": {
                    "type": "array",
                    "title": "My Array Property",
                    "readonly": true,
                    "items": {
                        $ref: "String"
                    }
                }
```