### PR TITLE
Auto increment IFD version at each build

### DIFF
--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
@@ -45,7 +45,7 @@ async function loadIA()
     // create the ifd as json object
     // and add metadatas filled from decorators
     globalThisAny.intuiface_ifd_file = {
-        'version': 'v1.0',
+        'version': `v1.0.${Date.now()}`,
         'name': '<%= IAName %>',
         'title': globalThisAny.iaTitle,
         'protocol': 'ts',


### PR DESCRIPTION
Include a timestamp in the version when generating ifd file.
This way, each time Interface Asset is built, version is increased and Composer will update IA when opening an experience containing older version.