### PR TITLE
fix(core): PN-2933 use displayName in Action

### DIFF
--- a/libs/core/src/lib/decorators/action.ts
+++ b/libs/core/src/lib/decorators/action.ts
@@ -55,6 +55,7 @@ export function Action(options?: IActionOptions)
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             id: `${globalThis.intuiface_ifd_name}.${propertyKey.toString()}`,
             path: propertyKey,
+            title: options.displayName,
             description: options.description,
             parameters: parameters
         };


### PR DESCRIPTION
Manage the display name of an action as it was not used in Composer. 