### PR TITLE
PN-3170: Composer Integration

### DIFF
--- a/libs/core/src/lib/decorators/element.decorator.ts
+++ b/libs/core/src/lib/decorators/element.decorator.ts
@@ -90,6 +90,12 @@ export function Asset(options?: IElementOptions): (cls: any) => any
     {
         const targetName = options.name;
         globalThis.iaTitle = options.displayName;
+
+        if (options.description != null)
+        {
+            globalThis.iaDescription = options.description;
+        }
+
         if (globalThis.intuiface_ifd_classes.indexOf(targetName) === -1)
         {
             globalThis.intuiface_ifd_classes.push(targetName);

--- a/libs/core/src/lib/decorators/parameter.ts
+++ b/libs/core/src/lib/decorators/parameter.ts
@@ -73,7 +73,8 @@ export function Parameter(options?: IParameterOptions): Function
         // store datas
         globalThis.intuiface_ifd_params[targetName][propertyKey][options.name] = {
             type: typeAndFormat.type,
-            title: options.displayName
+            title: options.displayName,
+            description: options.description ?? options.displayName
         };
 
         // add the format if defined

--- a/libs/core/src/lib/decorators/trigger.ts
+++ b/libs/core/src/lib/decorators/trigger.ts
@@ -59,6 +59,7 @@ export function Trigger(options?: ITriggerOptions)
         globalThis.intuiface_ifd_triggers[targetName][options.name] = {
             id: propertyKey,
             title: options.displayName,
+            description: options.description,
             properties: properties
         };
     };

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/package.json
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npm run cleanDist && npx tsc --project tsconfig.ifd.json && shx cp ./src/package.json ./tmp/ && node --experimental-modules --es-module-specifier-resolution=node tmp/index_ifd.js && npm run cleanTmp && npx webpack --config webpack.config.js && npm run build",
+    "build": "npm run cleanDist && npx tsc --project tsconfig.ifd.json && shx cp ./src/package.json ./tmp/ && node --experimental-modules --es-module-specifier-resolution=node tmp/index_ifd.js && npm run cleanTmp && npx webpack --config webpack.config.js",
+    "build:composer": "npm run cleanDist && npx tsc --project tsconfig.ifd.json && shx cp ./src/package.json ./tmp/ && node --experimental-modules --es-module-specifier-resolution=node tmp/index_ifd.js && npm run cleanTmp && npx webpack --config webpack.config.js && npm run postBuild",
     "build:debug": "npm run cleanDist && npx tsc --project tsconfig.ifd.json && shx cp ./src/package.json ./tmp/ && node --experimental-modules --es-module-specifier-resolution=node tmp/index_ifd.js && npm run cleanTmp && npx webpack --config webpack-debug.config.js",
     "lint": "npx eslint -c .eslintrc.js --ext .ts .",
     "cleanDist": "node -e \"require('fs-extra').remove('dist/');\"",

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/package.json
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/package.json
@@ -5,11 +5,12 @@
   "private": true,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npm run cleanDist && npx tsc --project tsconfig.ifd.json && shx cp ./src/package.json ./tmp/ && node --experimental-modules --es-module-specifier-resolution=node tmp/index_ifd.js && npm run cleanTmp && npx webpack --config webpack.config.js",
+    "build": "npm run cleanDist && npx tsc --project tsconfig.ifd.json && shx cp ./src/package.json ./tmp/ && node --experimental-modules --es-module-specifier-resolution=node tmp/index_ifd.js && npm run cleanTmp && npx webpack --config webpack.config.js && npm run build",
     "build:debug": "npm run cleanDist && npx tsc --project tsconfig.ifd.json && shx cp ./src/package.json ./tmp/ && node --experimental-modules --es-module-specifier-resolution=node tmp/index_ifd.js && npm run cleanTmp && npx webpack --config webpack-debug.config.js",
     "lint": "npx eslint -c .eslintrc.js --ext .ts .",
     "cleanDist": "node -e \"require('fs-extra').remove('dist/');\"",
-    "cleanTmp": "node -e \"require('fs-extra').remove('tmp/');\""
+    "cleanTmp": "node -e \"require('fs-extra').remove('tmp/');\"",
+    "postBuild": "shx cp -r dist/<%= IAName %>* ../../Free/<%= IAName %>/"
   },
   "keywords": [],
   "author": "",

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
@@ -41,6 +41,8 @@ async function loadIA()
 
     // set interface asset to import in composer
     resources['<%= IAName %>']['if.interfaceAsset'] = true;
+    resources['<%= IAName %>']['title'] = globalThisAny.iaTitle;
+    resources['<%= IAName %>']['description'] = globalThisAny.iaDescription;
 
     // create the ifd as json object
     // and add metadatas filled from decorators

--- a/libs/tools/schematics/interface-asset-schematics/src/workspace-template/gitignore
+++ b/libs/tools/schematics/interface-asset-schematics/src/workspace-template/gitignore
@@ -1,1 +1,8 @@
+# compiled output
+/dist
+
+# IDE - VSCode
+.vscode/*
+
+# dependencies
 node_modules/


### PR DESCRIPTION
This branch fixes various problems that I encountered when integrating URLParser in Composer:
- Adding IA title and description to `"ressources"`, where it's correctly interpreted
- Adding Descriptions to all decorators
- Adding `dist` and `.vscode` to `;gitignore`
- Adding a `build:composer` command, that also copies the IA files to the output folder