### PR TITLE
feat(interface-asset): Add Category property to Asset and Collections

### DIFF
--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -221,6 +221,7 @@ Squeleton of an interface asset class:
  */
 @Asset({
     name: 'MyCustomInterfaceAsset',
+    category: 'My Custom Interface Asset Category'
     behaviors: []
 })
 export class MyCustomInterfaceAsset extends IntuifaceElement {

--- a/docs/core/interfaces/IElementOptions.md
+++ b/docs/core/interfaces/IElementOptions.md
@@ -14,9 +14,9 @@ Options to configure [`@Asset`](../README.md#asset) decorator.
 
 - [behaviors](IElementOptions.md#behaviors)
 - [name](IElementOptions.md#name)
+- [category](IElementOptions.md#category)
 - [displayName](IElementOptions.md#displayname)
 - [description](IElementOptions.md#description)
-- [category](IElementOptions.md#category)
 
 ## Properties
 
@@ -42,6 +42,14 @@ Name used for serialization and identification
 
 ___
 
+### category
+
+• **category**: `string`
+
+Category in Composer's Interface Assets panel.
+
+___
+
 ### displayName
 
 • `Optional` **displayName**: `string`
@@ -55,14 +63,6 @@ ___
 • `Optional` **description**: `string`
 
 Description displayed in Composer.
-
-___
-
-### category
-
-• `Optional` **category**: `string`
-
-Category in Composer's Interface Assets panel.
 
 
 ## Help

--- a/docs/core/interfaces/IElementOptions.md
+++ b/docs/core/interfaces/IElementOptions.md
@@ -16,6 +16,7 @@ Options to configure [`@Asset`](../README.md#asset) decorator.
 - [name](IElementOptions.md#name)
 - [displayName](IElementOptions.md#displayname)
 - [description](IElementOptions.md#description)
+- [category](IElementOptions.md#category)
 
 ## Properties
 
@@ -54,6 +55,14 @@ ___
 • `Optional` **description**: `string`
 
 Description displayed in Composer.
+
+___
+
+### category
+
+• `Optional` **category**: `string`
+
+Category in Composer's Interface Assets panel.
 
 
 ## Help

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -221,6 +221,7 @@ Squeleton of an interface asset class:
  */
 @Asset({
     name: 'MyCustomInterfaceAsset',
+    category: 'My Custom Interface Asset Category'
     behaviors: []
 })
 export class MyCustomInterfaceAsset extends IntuifaceElement {

--- a/libs/core/src/lib/decorators/element.decorator.ts
+++ b/libs/core/src/lib/decorators/element.decorator.ts
@@ -35,7 +35,7 @@ export interface IElementOptions extends IInjectOptions
     /**
     * Category in Composer's Interface Assets panel.
     */
-    category?: string;
+    category: string;
 }
 
 /**
@@ -68,7 +68,7 @@ export interface ICollectionOptions extends IInjectOptions
     /**
      * Category in Composer's Interface Assets panel.
      */
-    category?: string;
+    category: string;
 }
 
 /**
@@ -180,15 +180,11 @@ export function Asset(options?: IElementOptions): (cls: any) => any
     {
         const targetName = options.name;
         globalThis.iaTitle = options.displayName;
+        globalThis.iaCategory = options.category;
 
         if (options.description != null)
         {
             globalThis.iaDescription = options.description;
-        }
-
-        if(options.category != null)
-        {
-            globalThis.iaCategory = options.category;
         }
 
         if (globalThis.intuiface_ifd_classes.indexOf(targetName) === -1)
@@ -230,11 +226,7 @@ export function Collection(options?: ICollectionOptions): (cls: any) => any
 {
     return (ctor: Function) => {
         const targetName = options.name;
-
-        if(options.category != null)
-        {
-            globalThis.iaCategory = options.category;
-        }
+        globalThis.iaCategory = options.category;
 
         if (globalThis.intuiface_ifd_classes.indexOf(targetName) === -1) {
             globalThis.intuiface_ifd_classes.push(targetName);

--- a/libs/core/src/lib/decorators/element.decorator.ts
+++ b/libs/core/src/lib/decorators/element.decorator.ts
@@ -31,6 +31,11 @@ export interface IElementOptions extends IInjectOptions
      * Description displayed in Composer.
      */
     description?: string;
+
+    /**
+    * Category in Composer's Interface Assets panel.
+    */
+    category?: string;
 }
 
 /**
@@ -59,6 +64,11 @@ export interface ICollectionOptions extends IInjectOptions
      * Description displayed in Composer.
      */
     description?: string;
+
+    /**
+     * Category in Composer's Interface Assets panel.
+     */
+    category?: string;
 }
 
 /**
@@ -104,6 +114,7 @@ export function DoNotInjectMethod() {
  *  *\/
  * @Asset({
  *     name: 'MyCustomInterfaceAsset',
+ *     category: 'My Custom Interface Asset Category'
  *     behaviors: []
  * })
  * export class MyCustomInterfaceAsset extends IntuifaceElement {
@@ -175,6 +186,11 @@ export function Asset(options?: IElementOptions): (cls: any) => any
             globalThis.iaDescription = options.description;
         }
 
+        if(options.category != null)
+        {
+            globalThis.iaCategory = options.category;
+        }
+
         if (globalThis.intuiface_ifd_classes.indexOf(targetName) === -1)
         {
             globalThis.intuiface_ifd_classes.push(targetName);
@@ -214,6 +230,12 @@ export function Collection(options?: ICollectionOptions): (cls: any) => any
 {
     return (ctor: Function) => {
         const targetName = options.name;
+
+        if(options.category != null)
+        {
+            globalThis.iaCategory = options.category;
+        }
+
         if (globalThis.intuiface_ifd_classes.indexOf(targetName) === -1) {
             globalThis.intuiface_ifd_classes.push(targetName);
         }

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/src/__IAName__.ts
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/src/__IAName__.ts
@@ -5,7 +5,8 @@ import { Action, Asset, IntuifaceElement, Parameter, Property, Trigger } from '@
  */
 @Asset({
     name: '<%= IAName %>',
-    behaviors: []
+    category: '<%= IACategory %>',
+    behaviors: [],
 })
 export class <%= IAName %> extends IntuifaceElement {
 

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
@@ -50,6 +50,7 @@ async function loadIA()
         'version': `v1.0.${Date.now()}`,
         'name': '<%= IAName %>',
         'title': globalThisAny.iaTitle,
+        'if.category': globalThisAny.iaCategory,
         'protocol': 'ts',
         'basePath': '<%= IAName %>',
         'if.dependencies': [

--- a/libs/tools/schematics/interface-asset-schematics/src/create/schema.json
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/schema.json
@@ -13,6 +13,15 @@
                 "$source": "argv",
                 "index": 0
             }
+        },
+        "IACategory": {
+            "type": "string",
+            "description": "The category in Composer's Interface Asset panel",
+            "x-prompt": "What is the category in Composer's Interface Asset panel name ?",
+            "$default": {
+                "$source": "argv",
+                "index": 1
+            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,12 +76,12 @@
     },
     "libs/components": {
       "name": "@intuiface/components",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT"
     },
     "libs/core": {
       "name": "@intuiface/core",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "MIT"
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
- When creating an IA via the CDK, we can’t give it a category. This is mandatory information when integrating that IA in the Composer.
