### PR TITLE
refactor(core)!: USBSerialService and expose createInstance in order to deprecate the getInstance function in the future

### DIFF
--- a/docs/core/classes/UsbSerialService.md
+++ b/docs/core/classes/UsbSerialService.md
@@ -7,6 +7,7 @@ Usb serial service to access to usb port, open it and write to it
 ### Methods
 
 - [getInstance](UsbSerialService.md#getinstance)
+- [createInstance](UsbSerialService.md#createinstance)
 - [list](UsbSerialService.md#list)
 - [open](UsbSerialService.md#open)
 - [write](UsbSerialService.md#write)
@@ -19,9 +20,23 @@ Usb serial service to access to usb port, open it and write to it
 
 ### getInstance
 
-▸ `Static` **getInstance**(): `any`
+▸ `Static` **getInstance**(): `void`
 
-Get instance
+#### Returns
+
+`void`
+
+**`Deprecated`**
+
+- Get instance,  Use the new [createInstance](UsbSerialService.md#createinstance) instead.
+
+___
+
+### createInstance
+
+▸ `Static` **createInstance**(): `any`
+
+Create instance
 
 #### Returns
 

--- a/docs/core/classes/UsbSerialService.md
+++ b/docs/core/classes/UsbSerialService.md
@@ -22,13 +22,17 @@ Usb serial service to access to usb port, open it and write to it
 
 ▸ `Static` **getInstance**(): `void`
 
+Get instance, get the instance of the usb serial service.
+
 #### Returns
 
 `void`
 
+an instance of the usb serial service
+
 **`Deprecated`**
 
-- Get instance,  Use the new [createInstance](UsbSerialService.md#createinstance) instead.
+Use the new [createInstance](UsbSerialService.md#createinstance) instead.
 
 ___
 
@@ -36,11 +40,13 @@ ___
 
 ▸ `Static` **createInstance**(): `any`
 
-Create instance
+Create instance, create the instance of the usb serial service.
 
 #### Returns
 
 `any`
+
+an instance of the usb serial service
 
 ___
 

--- a/docs/core/classes/UsbSerialService.md
+++ b/docs/core/classes/UsbSerialService.md
@@ -20,13 +20,13 @@ Usb serial service to access to usb port, open it and write to it
 
 ### getInstance
 
-▸ `Static` **getInstance**(): `void`
+▸ `Static` **getInstance**(): `any`
 
 Get instance, get the instance of the usb serial service.
 
 #### Returns
 
-`void`
+`any`
 
 an instance of the usb serial service
 

--- a/libs/core/src/lib/services/usb.serial.service.ts
+++ b/libs/core/src/lib/services/usb.serial.service.ts
@@ -8,10 +8,17 @@ export class UsbSerialService {
     protected static instance;
 
     /**
-     * Get instance
+     * @Deprecated - Get instance,  Use the new {@link createInstance} instead.
      * @returns
      */
     public static getInstance() {
+    }
+
+    /**
+     * Create instance
+     * @returns
+     */
+    public static createInstance() {
         return UsbSerialService.instance;
     }
 

--- a/libs/core/src/lib/services/usb.serial.service.ts
+++ b/libs/core/src/lib/services/usb.serial.service.ts
@@ -13,7 +13,7 @@ export class UsbSerialService {
      * @deprecated Use the new {@link createInstance} instead.
      */
     public static getInstance() {
-        UsbSerialService.createInstance();
+        return UsbSerialService.createInstance();
     }
 
     /**

--- a/libs/core/src/lib/services/usb.serial.service.ts
+++ b/libs/core/src/lib/services/usb.serial.service.ts
@@ -8,15 +8,17 @@ export class UsbSerialService {
     protected static instance;
 
     /**
-     * @Deprecated - Get instance,  Use the new {@link createInstance} instead.
-     * @returns
+     * Get instance, get the instance of the usb serial service.
+     * @returns an instance of the usb serial service
+     * @deprecated Use the new {@link createInstance} instead.
      */
     public static getInstance() {
+        UsbSerialService.createInstance();
     }
 
     /**
-     * Create instance
-     * @returns
+     * Create instance, create the instance of the usb serial service.
+     * @returns an instance of the usb serial service
      */
     public static createInstance() {
         return UsbSerialService.instance;


### PR DESCRIPTION
getInstance function of USBSerialService will be deprecated and replaced by createInstance