### PR TITLE
feature(interface-asset): Allow usage of `window` in interface asset

### DIFF
--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/package.json
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
+    "@types/jsdom": "^21.1.7",
     "@types/node": "^18.11.10",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/eslint-plugin-tslint": "^5.10.1",
@@ -24,6 +25,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "fs-extra": "^10.1.0",
+    "jsdom": "^25.0.0",
     "shx": "^0.3.4",
     "ts-loader": "^9.4.1",
     "tslint": "6.1.3",

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/src/index_ifd.ts
@@ -2,6 +2,7 @@
 /* eslint-disable dot-notation */
 // const fs = require('fs-extra');
 import fs from 'fs-extra';
+import { JSDOM } from 'jsdom';
 
 // create object to store metadatas
 const globalThisAny = globalThis as any;
@@ -11,6 +12,15 @@ globalThisAny.intuiface_ifd_properties = {};
 globalThisAny.intuiface_ifd_actions = {};
 globalThisAny.intuiface_ifd_params = {};
 globalThisAny.intuiface_ifd_triggers = {};
+
+// Initialize dom feature
+globalThisAny.window = new JSDOM('', {url: 'https://web.intuiface.com/'}).window;
+// Inject everything from `window` into global scope
+for (const key in globalThisAny.window) {
+    if (Object.prototype.hasOwnProperty.call(globalThisAny.window, key) && globalThisAny[key] === undefined) {
+        globalThisAny[key] = globalThisAny.window[key];
+    }
+}
 
 /**
  * import the IA


### PR DESCRIPTION
When generating ifd with nodejs, if an interface asset is using global scope variables such as `window` or `navigator`, the generation was failing with error like:

```
ReferenceError: window is not defined
```
or
```
ReferenceError: navigator is not defined
```

The workaround was to reference `window` only inside method of the interface asset, not outside of the class. But this was not possible to import a library referencing `window` or `navigator` at load time.

This PR make it possible to use `window` or `navigator` in every part of the code, even outside the declared class or in an imported third party library. The script generating the ifd file now use `jsdom` library to mock DOM objects.