### PR TITLE
fix(core): add default values to parameters in ifd file

### DIFF
--- a/libs/core/src/lib/decorators/parameter.ts
+++ b/libs/core/src/lib/decorators/parameter.ts
@@ -130,7 +130,8 @@ export function Parameter(options?: IParameterOptions): Function
         globalThis.intuiface_ifd_params[targetName][propertyKey][options.name] = {
             type: typeAndFormat.type,
             title: options.displayName,
-            description: options.description ?? options.displayName
+            description: options.description ?? options.displayName,
+            default: options.defaultValue
         };
 
         // add the format if defined

--- a/libs/core/src/lib/decorators/parameter.ts
+++ b/libs/core/src/lib/decorators/parameter.ts
@@ -130,14 +130,19 @@ export function Parameter(options?: IParameterOptions): Function
         globalThis.intuiface_ifd_params[targetName][propertyKey][options.name] = {
             type: typeAndFormat.type,
             title: options.displayName,
-            description: options.description ?? options.displayName,
-            default: options.defaultValue
+            description: options.description ?? options.displayName
         };
 
         // add the format if defined
         if (typeAndFormat.format)
         {
             globalThis.intuiface_ifd_params[targetName][propertyKey][options.name].format = typeAndFormat.format;
+        }
+
+        // add default value for parameter if defined
+        if (options.defaultValue !== undefined)
+        {
+            globalThis.intuiface_ifd_params[targetName][propertyKey][options.name].default = options.defaultValue;
         }
 
     };


### PR DESCRIPTION
Parameters of triggers and actions has defaultValue but this default value is not written in ifd file and cannot be use in Composer or Player.

To fix https://intuilab.atlassian.net/browse/PN-3900, I added `default` in ifd file for parameters