### PR TITLE
ci(*): add pre-release package workflow

### DIFF
--- a/.github/workflows/pre-release-package.yml
+++ b/.github/workflows/pre-release-package.yml
@@ -1,0 +1,54 @@
+name: Intuiface-CDK Pre-Release Package
+
+on:
+  push:
+    branches:
+      - 'release-please--branches--master**'
+
+jobs:
+
+  publish-prerelease:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@intuiface'
+
+      - name: Compute pre-release version
+        id: version
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          PRE_VERSION="${BASE_VERSION}-rc.${SHORT_SHA}"
+          echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "pre_version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Pre-release version: $PRE_VERSION"
+
+      - name: Set pre-release version in all packages
+        run: node set-prerelease-version.mjs "${{ steps.version.outputs.pre_version }}"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build packages
+        run: npm run build
+
+      - name: Publish core to npmjs packages
+        run: npm publish dist/libs/core --access public --tag next
+
+      - name: Publish components to npmjs packages
+        run: npm publish dist/libs/components --access public --tag next
+
+      - name: Publish cli to npmjs packages
+        run: npm publish dist/libs/cli --access public --tag next
+
+      - name: Publish interface-asset to npmjs packages
+        run: npm publish dist/libs/tools/interface-asset-schematics --access public --tag next

--- a/.github/workflows/pre-release-package.yml
+++ b/.github/workflows/pre-release-package.yml
@@ -1,10 +1,7 @@
 name: Intuiface-CDK Pre-Release Package
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    branches:
-      - 'release-please--branches--master**'
+  workflow_dispatch:
 
 jobs:
 
@@ -15,6 +12,13 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Validate branch name
+        run: |
+          if [[ "${{ github.ref_name }}" != release-please--branches--master* ]]; then
+            echo "Branch '${{ github.ref_name }}' can't be pre-released. Only RC branch from release-please can be published."
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/pre-release-package.yml
+++ b/.github/workflows/pre-release-package.yml
@@ -1,7 +1,8 @@
 name: Intuiface-CDK Pre-Release Package
 
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize]
     branches:
       - 'release-please--branches--master**'
 

--- a/set-prerelease-version.mjs
+++ b/set-prerelease-version.mjs
@@ -1,0 +1,36 @@
+import fs from 'fs';
+
+/**
+ * Updates a value at the given JSONPath in a JSON file.
+ * Supports paths like "$.version" or "$.dependencies['@intuiface/core']".
+ */
+const updateJson = (filePath, jsonPath, value) => {
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const parts = jsonPath.replace(/^\$\./, '').split(/[.\[\]']+/).filter(Boolean);
+    let obj = content;
+    for (let i = 0; i < parts.length - 1; i++) {
+        obj = obj[parts[i]];
+    }
+    obj[parts[parts.length - 1]] = value;
+    fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + '\n');
+};
+
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+    console.error('Usage: node set-prerelease-version.mjs <pre-release-version>');
+    process.exit(1);
+}
+
+const preReleaseVersion = args[0];
+
+// Update root package.json version
+updateJson('package.json', '$.version', preReleaseVersion);
+console.log('Updated package.json $.version');
+
+// Read release-please config and update all extra-files entries
+const config = JSON.parse(fs.readFileSync('release-please-config.json', 'utf8'));
+for (const entry of config.packages['.']['extra-files']) {
+    const filePath = entry.path.replace(/^\//, '');
+    updateJson(filePath, entry.jsonpath, preReleaseVersion);
+    console.log(`Updated ${filePath} ${entry.jsonpath}`);
+}


### PR DESCRIPTION
- Automatically publish release candidates to npm
- Trigger whenever release branches are updated
- Generate version numbers using commit hashes
- Use pre-release tags for early package testing