### PR TITLE
fix(intuiface-cdk): Update TypeScript configuration 

### DIFF
--- a/libs/cli/src/cli.ts
+++ b/libs/cli/src/cli.ts
@@ -434,6 +434,9 @@ function migrateProject(): void
                 tsconfig.compilerOptions.outDir = `./dist/${iaName}`;
                 tsconfig.compilerOptions.target = 'ES2022';
                 tsconfig.compilerOptions.useDefineForClassFields = false;
+                tsconfig.compilerOptions.rootDir = '.';
+                tsconfig.compilerOptions.moduleResolution = 'bundler';
+                delete tsconfig.compilerOptions.downlevelIteration;
                 tsconfig.include = ['**/src/**/*.ts'];
                 // write tsconfig.json
                 fs.writeFileSync(`${dir}/tsconfig.json`, JSON.stringify(tsconfig, null, 2));

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/src/__IAName__.ts
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/src/__IAName__.ts
@@ -35,7 +35,7 @@ export class <%= IAName %> extends IntuifaceElement {
     /**
      * A private property example
      */
-    private _privateStr: string = null;
+    private _privateStr: string = '';
 
     //#endregion Private Properties
 

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/tsconfig.json
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/tsconfig.json
@@ -15,9 +15,9 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop" : true,    
     "declaration": false,
-    "downlevelIteration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
+    "rootDir": "."
   },
   "exclude": ["node_modules"],
   "include": ["**/src/**/*.ts"]

--- a/libs/tools/schematics/interface-asset-schematics/src/create/files/tsconfig.json
+++ b/libs/tools/schematics/interface-asset-schematics/src/create/files/tsconfig.json
@@ -17,7 +17,7 @@
     "declaration": false,
     "moduleResolution": "bundler",
     "importHelpers": true,
-    "rootDir": "."
+    "rootDir": "./src"
   },
   "exclude": ["node_modules"],
   "include": ["**/src/**/*.ts"]


### PR DESCRIPTION
Fixes : 

- The `downLevelIteration` parameter isn't needed. : [downleveliteration deprecated](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#deprecated---downleveliteration)
- `moduleResolution` from `node` to `bundler` : [Explanation](https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3511889471)
- Add `rootDir` parameter : [TS Migration](https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348659946)
